### PR TITLE
Keep it low

### DIFF
--- a/functions/redirect.js
+++ b/functions/redirect.js
@@ -1,10 +1,11 @@
 export async function handler(event) {
   const [, res] = event.path.split('/')
+  const name = res.toLowerCase() || '404'
 
   return {
     statusCode: 302,
     headers: {
-      Location: `https://raw.githubusercontent.com/vikiival/trap/master/images/${res || '404'}.png`,
+      Location: `https://raw.githubusercontent.com/vikiival/trap/master/images/${name}.png`,
     }
   }
 }


### PR DESCRIPTION
The path parameter is lowercased so Well will show

<img src="https://trap.ltd/well" />
