### PR TITLE
use static

### DIFF
--- a/functions/redirect.js
+++ b/functions/redirect.js
@@ -22,7 +22,7 @@ export async function handler(event) {
   return {
     statusCode: 302,
     headers: {
-      Location: `https://raw.githubusercontent.com/vikiival/trap/master/images/${name}.png`,
+      Location: `/images/${name}.png`,
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
 
         const images = json.map((file) => ({
           name: file?.name?.split('.')[0] || 'Error',
-          url: file?.download_url || 'https://http.cat/418',
+          url: file?.name ? `/images/${file?.name}` : 'https://http.cat/418',
         }))
 
         const section = document.querySelector('section')

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,11 @@
   status = 200
 
 [[redirects]]
+  from = "/images/*"
+  to = "/images/:splat"
+  status = 200  
+
+[[redirects]]
   from = "/*"
   to = "/.netlify/functions/redirect"
   status = 200


### PR DESCRIPTION
As Patrick from DC served mentioned we could serve images directly from the Netlify CDN which should be much faaaster

- :zap: app prefers to load static images
- :zap: redirect function prefers server images over github
